### PR TITLE
Fix multi-copy to local library failures after first item

### DIFF
--- a/Sources/ABSClientMac/AppViewModel.swift
+++ b/Sources/ABSClientMac/AppViewModel.swift
@@ -14,6 +14,20 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+    private enum LocalCopyError: LocalizedError {
+        case sourceAlreadyLocal
+        case localRootUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .sourceAlreadyLocal:
+                return "Item is already in a local library"
+            case .localRootUnavailable:
+                return "Selected local library folder is unavailable"
+            }
+        }
+    }
+
     @Published var serverScheme: String = "http"
     @Published var serverHost: String = ""
     @Published var serverPortText: String = "13378"
@@ -530,12 +544,13 @@ final class AppViewModel: ObservableObject {
         targetRootID: String,
         progress: (@Sendable (Double) async -> Void)? = nil
     ) async throws -> URL {
-        guard !isLocalLibrary(id: selectedLibraryID) else {
-            throw DownloadFeatureError.unavailable
+        if let sourceItem = item(withID: itemID),
+           sourceItem.libraryID.hasPrefix(LocalLibraryManager.libraryIDPrefix) {
+            throw LocalCopyError.sourceAlreadyLocal
         }
 
         guard let targetRoot = localLibraryRoots.first(where: { $0.id == targetRootID }) else {
-            throw DownloadFeatureError.unavailable
+            throw LocalCopyError.localRootUnavailable
         }
 
         return try await downloadItemToDirectory(

--- a/Sources/ABSClientMac/ContentView.swift
+++ b/Sources/ABSClientMac/ContentView.swift
@@ -4926,10 +4926,8 @@ struct ContentView: View {
 
         let ordered = Array(Set(itemIDs)).sorted()
         let copyCandidates = ordered.filter { itemID in
-            if let item = viewModel.item(withID: itemID) {
-                return !item.libraryID.hasPrefix(LocalLibraryManager.libraryIDPrefix)
-            }
-            return true
+            guard let item = viewModel.item(withID: itemID) else { return false }
+            return !item.libraryID.hasPrefix(LocalLibraryManager.libraryIDPrefix)
         }
         guard !copyCandidates.isEmpty else { return }
 


### PR DESCRIPTION
## Summary
- fix multi-item local-copy flow so per-item copy does not depend on current selected library context
- validate local-source condition by item metadata instead of selected library
- skip unknown/stale selected IDs during bulk copy filtering
- add copy-specific error cases for clearer failure reasons

Fixes #32.

## Validation
- swift test
