### PR TITLE
Add per-book local metadata editor with quick match actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.1.0-beta.5] - 2026-03-06
+
+### Added
+- Local metadata matching and reconciliation workflow:
+  - Per-book metadata editor from item actions.
+  - Match actions and reconciliation support for local-library metadata updates.
+- Local library auto-refresh via file-system watching:
+  - Monitors library folders (including subfolders) for changes.
+  - Triggers automatic library updates when new or changed items are detected.
+- Local library file-organization settings:
+  - Template-based organization under library root (for example `Author/Series/Book`).
+  - Unmatched-item fallback handling for organization workflows.
+
+### Changed
+- Local-library context actions now open the configured local library root in Finder.
+- Local-library menu labeling was clarified to reduce confusion with remote download wording.
+- README release instructions were simplified by removing outdated notarization references.
+
+### Fixed
+- Multi-item copy to local library was hardened to avoid follow-on failures in queued operations.
+- Series normalization now strips ABS-style trailing sequence suffixes (for example `Series #1`) during folder resolution to prevent duplicate per-book series directories.
+
+### Commits Since 0.1.0-beta.4
+- `34f9884` feat(local): add metadata matching workflow and reconciliation notes (#27)
+- `c9b21c2` feat(local): watch local library folders and auto-refresh on changes
+- `42076f9` fix(local): open selected local library root in Finder and relabel menu
+- `20758df` fix(copy): make multi-copy resilient to library context changes
+- `aed4e9a` feat(local): add template-based local file organization settings
+- `91a046a` fix(local): normalize ABS series suffix when resolving folder template
+- `f94c268` Remove notarization instructions from README
+
 ## [0.1.0-beta.4] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Native macOS client for Audiobookshelf, built with SwiftUI and AVFoundation.
 
 indexd is currently in beta.
 
-- Latest release: `v0.1.0-beta.4`
+- Latest release: `v0.1.0-beta.5`
 - Changelog: [CHANGELOG.md](./CHANGELOG.md)
 
 ## Highlights
@@ -55,29 +55,29 @@ swift build -c release
 Create `.app` bundle:
 
 ```bash
-./scripts/package-app.sh 0.1.0-beta.4 1
+./scripts/package-app.sh 0.1.0-beta.5 1
 ```
 
 Generated artifacts:
 
 - `dist/indexd.app`
-- `dist/indexd-macos-v0.1.0-beta.4.zip` (if zipped for release)
+- `dist/indexd-macos-v0.1.0-beta.5.zip` (if zipped for release)
 
 Create release zip:
 
 ```bash
-ditto -c -k --sequesterRsrc --keepParent dist/indexd.app dist/indexd-macos-v0.1.0-beta.4.zip
+ditto -c -k --sequesterRsrc --keepParent dist/indexd.app dist/indexd-macos-v0.1.0-beta.5.zip
 ```
 
 ## Release Process (Beta)
 
 ```bash
 git add .
-git commit -m "Release v0.1.0-beta.4"
-git tag v0.1.0-beta.4
+git commit -m "Release v0.1.0-beta.5"
+git tag v0.1.0-beta.5
 git push origin main
-git push origin v0.1.0-beta.4
-gh release create v0.1.0-beta.4 dist/indexd-macos-v0.1.0-beta.4.zip --prerelease
+git push origin v0.1.0-beta.5
+gh release create v0.1.0-beta.5 dist/indexd-macos-v0.1.0-beta.5.zip --prerelease
 ```
 
 ## Contributing and Security

--- a/Sources/ABSClientMac/AppViewModel.swift
+++ b/Sources/ABSClientMac/AppViewModel.swift
@@ -21,6 +21,15 @@ final class AppViewModel: ObservableObject {
         let publishedYear: Int?
     }
 
+    struct CoverSearchResult: Identifiable, Hashable, Sendable {
+        let id: String
+        let source: String
+        let asin: String?
+        let title: String
+        let authors: [String]
+        let imageURL: URL
+    }
+
     private enum DownloadFeatureError: LocalizedError {
         case unavailable
 
@@ -625,6 +634,103 @@ final class AppViewModel: ObservableObject {
         return changed
     }
 
+    func searchAudibleCovers(
+        title: String,
+        author: String?,
+        limit: Int = 20
+    ) async throws -> [CoverSearchResult] {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return [] }
+        let trimmedAuthor = author?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var candidateASINs: [String] = []
+        if Self.isValidASIN(trimmedTitle) {
+            candidateASINs.append(trimmedTitle.uppercased())
+        } else {
+            var components = URLComponents(string: "https://api.audible.com/1.0/catalog/products")
+            var queryItems: [URLQueryItem] = [
+                URLQueryItem(name: "num_results", value: String(max(1, min(limit, 50)))),
+                URLQueryItem(name: "products_sort_by", value: "Relevance"),
+                URLQueryItem(name: "title", value: trimmedTitle)
+            ]
+            if let trimmedAuthor, !trimmedAuthor.isEmpty {
+                queryItems.append(URLQueryItem(name: "author", value: trimmedAuthor))
+            }
+            components?.queryItems = queryItems
+            guard let url = components?.url else { return [] }
+
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                return []
+            }
+            let decoded = try JSONDecoder().decode(AudibleCoverCatalogResponse.self, from: data)
+            candidateASINs = (decoded.products ?? []).compactMap { $0.asin?.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() }
+        }
+
+        if candidateASINs.isEmpty { return [] }
+
+        let uniqueASINs = Array(Set(candidateASINs)).prefix(max(1, min(limit, 30)))
+        let audnexusBooks: [AudnexusBookResponse] = await withTaskGroup(of: AudnexusBookResponse?.self) { group in
+            for asin in uniqueASINs {
+                group.addTask {
+                    await self.fetchAudnexusBook(asin: asin, region: "us")
+                }
+            }
+            var collected: [AudnexusBookResponse] = []
+            for await result in group {
+                if let result {
+                    collected.append(result)
+                }
+            }
+            return collected
+        }
+
+        var seenImageURLs = Set<String>()
+        var results: [CoverSearchResult] = []
+        for book in audnexusBooks {
+            guard let image = book.image?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  let imageURL = URL(string: image),
+                  !image.isEmpty else {
+                continue
+            }
+            let dedupeKey = imageURL.absoluteString.lowercased()
+            guard seenImageURLs.insert(dedupeKey).inserted else { continue }
+            let title = (book.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else { continue }
+            let authors = (book.authors ?? [])
+                .compactMap { $0.name?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
+            results.append(
+                CoverSearchResult(
+                    id: book.asin ?? UUID().uuidString,
+                    source: "Audible",
+                    asin: book.asin,
+                    title: title,
+                    authors: authors,
+                    imageURL: imageURL
+                )
+            )
+        }
+        return results
+    }
+
+    @discardableResult
+    func updateLocalItemCover(itemID: String, coverData: Data?) async throws -> Bool {
+        guard let item = item(withID: itemID) else { return false }
+        guard let rootID = rootID(forLocalLibraryID: item.libraryID) else { return false }
+
+        let changed = try await localLibraryManager.updateItemCoverData(
+            rootID: rootID,
+            itemID: itemID,
+            coverData: coverData
+        )
+        if changed {
+            await refreshLocalLibraries()
+        }
+        return changed
+    }
+
     func addLocalLibraryRoot(directoryURL: URL) async throws {
         _ = try await localLibraryManager.addRoot(directoryURL: directoryURL)
         await refreshLocalLibraries()
@@ -675,11 +781,22 @@ final class AppViewModel: ObservableObject {
             options: organizationOptions
         )
 
-        return try await downloadItemToDirectory(
+        let destinationURL = try await downloadItemToDirectory(
             itemID: itemID,
             directoryURL: destinationDirectory,
             progress: progress
         )
+
+        if let sourceItem {
+            _ = try await localLibraryManager.ingestCopiedFile(
+                rootID: targetRootID,
+                fileURL: destinationURL,
+                sourceItem: sourceItem
+            )
+            await refreshLocalLibraries()
+        }
+
+        return destinationURL
     }
 
     func allKnownItems() -> [ABSCore.LibraryItem] {
@@ -892,8 +1009,12 @@ final class AppViewModel: ObservableObject {
     private func uniqueDestinationURL(in directory: URL, itemID: String, remoteURL: URL) -> URL {
         let ext = remoteURL.pathExtension.isEmpty ? "m4b" : remoteURL.pathExtension
         let fallbackName = "book-\(itemID)"
-        let title = item(withID: itemID)?.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let baseName = sanitizedFileName((title?.isEmpty == false ? title! : fallbackName))
+        let sourceItem = item(withID: itemID)
+        let title = sourceItem?.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        var baseName = sanitizedFileName((title?.isEmpty == false ? title! : fallbackName))
+        if let sourceItem, isDramatizedEdition(sourceItem), !titleContainsDramatizedCue(sourceItem.title) {
+            baseName = sanitizedFileName("\(baseName) (Dramatized)")
+        }
 
         var candidate = directory.appendingPathComponent("\(baseName).\(ext)")
         var attempt = 2
@@ -1003,6 +1124,39 @@ final class AppViewModel: ObservableObject {
         let components = value.components(separatedBy: invalid)
         let joined = components.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         return joined.isEmpty ? "download" : joined
+    }
+
+    private func isDramatizedEdition(_ item: ABSCore.LibraryItem) -> Bool {
+        let signals = [
+            item.title,
+            item.blurb ?? "",
+            item.narrator ?? "",
+            item.author ?? "",
+            item.authors.joined(separator: " "),
+            item.tags.joined(separator: " "),
+            item.genres.joined(separator: " "),
+            item.collections.joined(separator: " ")
+        ].joined(separator: " ").lowercased()
+
+        let cues = [
+            "dramatized",
+            "dramatised",
+            "dramatic adaptation",
+            "dramatized adaptation",
+            "audio drama",
+            "full cast",
+            "graphicaudio",
+            "graphic audio"
+        ]
+        return cues.contains(where: { signals.contains($0) })
+    }
+
+    private func titleContainsDramatizedCue(_ title: String) -> Bool {
+        let normalized = title.lowercased()
+        return normalized.contains("dramatized")
+            || normalized.contains("dramatised")
+            || normalized.contains("adaptation")
+            || normalized.contains("full cast")
     }
 
     private func mergeDetailedItem(_ detailed: ABSCore.LibraryItem) {
@@ -1335,6 +1489,51 @@ final class AppViewModel: ObservableObject {
 
         return error.localizedDescription
     }
+
+    private func fetchAudnexusBook(asin: String, region: String) async -> AudnexusBookResponse? {
+        var components = URLComponents(string: "https://api.audnex.us/books/\(asin)")
+        components?.queryItems = [URLQueryItem(name: "region", value: region)]
+        guard let url = components?.url else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                return nil
+            }
+            return try JSONDecoder().decode(AudnexusBookResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func isValidASIN(_ value: String) -> Bool {
+        let upper = value.uppercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard upper.count == 10 else { return false }
+        return upper.allSatisfy { $0.isASCII && ($0.isNumber || ($0 >= "A" && $0 <= "Z")) }
+    }
+}
+
+private struct AudibleCoverCatalogResponse: Decodable {
+    struct Contributor: Decodable {
+        let name: String?
+    }
+
+    struct Product: Decodable {
+        let asin: String?
+    }
+
+    let products: [Product]?
+}
+
+private struct AudnexusBookResponse: Decodable {
+    struct Contributor: Decodable {
+        let name: String?
+    }
+
+    let asin: String?
+    let title: String?
+    let authors: [Contributor]?
+    let image: String?
 }
 
 private struct APIProgressRemote: ProgressRemoteSyncing {

--- a/Sources/ABSClientMac/ContentView.swift
+++ b/Sources/ABSClientMac/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AVFoundation
 import AppKit
 import OSLog
+import UniformTypeIdentifiers
 import ABSCore
 
 struct ContentView: View {
@@ -293,6 +294,13 @@ struct ContentView: View {
         var publishedYearText: String
     }
 
+    private enum MetadataEditorTab: String, CaseIterable, Identifiable {
+        case details = "Details"
+        case cover = "Cover"
+
+        var id: String { rawValue }
+    }
+
     private let mediaIntegration = MacMediaIntegrationManager.shared
     private let progressDefaultsKey = "abs.local.progress.v1"
     private let progressHistoryDefaultsKey = "abs.local.progress.history.v1"
@@ -388,6 +396,16 @@ struct ContentView: View {
     )
     @State private var metadataEditorBusy = false
     @State private var metadataEditorErrorMessage: String?
+    @State private var metadataEditorTab: MetadataEditorTab = .details
+    @State private var metadataCoverSearchTitle = ""
+    @State private var metadataCoverSearchAuthor = ""
+    @State private var metadataCoverSearchResults: [AppViewModel.CoverSearchResult] = []
+    @State private var metadataCoverSearchBusy = false
+    @State private var metadataSelectedCoverResultID: String?
+    @State private var metadataPendingCoverData: Data?
+    @State private var metadataPendingCoverImage: NSImage?
+    @State private var metadataCoverURLText = ""
+    @State private var showingMetadataCoverFileImporter = false
     @State private var showingManualMetadataMatch = false
     @State private var manualMetadataMatchQuery = ""
     @State private var manualMetadataMatchCandidates: [MetadataMatchCandidate] = []
@@ -851,12 +869,14 @@ struct ContentView: View {
                 ) {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 72), spacing: 6)], alignment: .leading, spacing: 6) {
                         ForEach(libraryBrowseTabs, id: \.rawValue) { tab in
+                            let isSelectedLibrary = viewModel.selectedLibraryID == library.id
+                            let isActiveTab = isSelectedLibrary && currentBrowseTab(for: library.id) == tab
                             Button(tab.rawValue) {
                                 selectLibrary(libraryID: library.id, browseTab: tab)
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.mini)
-                            .tint(currentBrowseTab(for: library.id) == tab ? .accentColor : .gray.opacity(0.32))
+                            .tint(isActiveTab ? .accentColor : .gray.opacity(0.32))
                         }
                     }
                     .padding(.vertical, 4)
@@ -1182,8 +1202,11 @@ struct ContentView: View {
                 itemListRowCover(for: item)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(item.title)
-                        .font(.headline)
+                    HStack(spacing: 6) {
+                        Text(item.title)
+                            .font(.headline)
+                        editionBadge(for: item)
+                    }
                     if let author = item.author {
                         Text(author)
                             .font(.subheadline)
@@ -1248,13 +1271,6 @@ struct ContentView: View {
                         Task { await setPlayedState(for: contextItemIDs, isPlayed: false) }
                     }
                 } else {
-                    Button("Edit Metadata…") {
-                        openMetadataEditor(for: item.id)
-                    }
-                    .disabled(!viewModel.canEditMetadata(itemID: item.id))
-
-                    Divider()
-
                     Button("Start from Beginning") {
                         selectedItemID = item.id
                         selectedItemIDs = [item.id]
@@ -1290,6 +1306,13 @@ struct ContentView: View {
                             Task { await setPlayedState(for: [item.id], isPlayed: true) }
                         }
                     }
+
+                    Divider()
+
+                    Button("Edit Metadata…") {
+                        openMetadataEditor(for: item.id)
+                    }
+                    .disabled(!viewModel.canEditMetadata(itemID: item.id))
 
                     Divider()
 
@@ -1490,8 +1513,11 @@ struct ContentView: View {
                                             .font(.caption.weight(.semibold))
                                             .foregroundStyle(.secondary)
                                     }
-                                    Text(item.title)
-                                        .font(.headline)
+                                    HStack(spacing: 6) {
+                                        Text(item.title)
+                                            .font(.headline)
+                                        editionBadge(for: item)
+                                    }
                                     if let author = item.author {
                                         Text(author)
                                             .font(.subheadline)
@@ -1539,11 +1565,14 @@ struct ContentView: View {
                         }
 
                         VStack(spacing: 8) {
-                            Text(item.title)
-                                .font(.largeTitle)
-                                .lineLimit(3)
-                                .minimumScaleFactor(0.75)
-                                .multilineTextAlignment(.center)
+                            VStack(spacing: 6) {
+                                Text(item.title)
+                                    .font(.largeTitle)
+                                    .lineLimit(3)
+                                    .minimumScaleFactor(0.75)
+                                    .multilineTextAlignment(.center)
+                                editionBadge(for: item)
+                            }
                             let authors = displayAuthorNames(for: item)
                             if !authors.isEmpty {
                                 VStack(spacing: 2) {
@@ -1647,6 +1676,10 @@ struct ContentView: View {
                             if let series = seriesValue(for: item) {
                                 detailRow(title: "Series", value: series)
                             }
+                            detailRow(
+                                title: "Edition",
+                                value: editionVariant(for: item) == .dramatized ? "Dramatized" : "Standard"
+                            )
                             if let publisher = item.publisher, !publisher.isEmpty {
                                 detailRow(title: "Publisher", value: publisher)
                             }
@@ -3026,25 +3059,41 @@ struct ContentView: View {
 
     private var metadataEditorSheet: some View {
         NavigationStack {
-            Form {
-                Section("Details") {
-                    TextField("Title", text: $metadataEditorDraft.title)
-                    TextField("Authors (comma-separated)", text: $metadataEditorDraft.authorsText)
-                    TextField("Narrators (comma-separated)", text: $metadataEditorDraft.narrator)
-                    TextField("Series", text: $metadataEditorDraft.seriesName)
-                    TextField("Publish Year", text: $metadataEditorDraft.publishedYearText)
-                    TextField("Publisher", text: $metadataEditorDraft.publisher)
-                    TextField("Language", text: $metadataEditorDraft.language)
+            VStack(spacing: 0) {
+                Picker("Metadata Tab", selection: $metadataEditorTab) {
+                    ForEach(MetadataEditorTab.allCases) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
                 }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
 
-                Section("Description") {
-                    TextEditor(text: $metadataEditorDraft.blurb)
-                        .frame(minHeight: 100)
-                }
+                if metadataEditorTab == .details {
+                    Form {
+                        Section("Details") {
+                            TextField("Title", text: $metadataEditorDraft.title)
+                            TextField("Authors (comma-separated)", text: $metadataEditorDraft.authorsText)
+                            TextField("Narrators (comma-separated)", text: $metadataEditorDraft.narrator)
+                            TextField("Series", text: $metadataEditorDraft.seriesName)
+                            TextField("Publish Year", text: $metadataEditorDraft.publishedYearText)
+                            TextField("Publisher", text: $metadataEditorDraft.publisher)
+                            TextField("Language", text: $metadataEditorDraft.language)
+                        }
 
-                Section("Classification") {
-                    TextField("Genres (comma-separated)", text: $metadataEditorDraft.genresText)
-                    TextField("Tags (comma-separated)", text: $metadataEditorDraft.tagsText)
+                        Section("Description") {
+                            TextEditor(text: $metadataEditorDraft.blurb)
+                                .frame(minHeight: 100)
+                        }
+
+                        Section("Classification") {
+                            TextField("Genres (comma-separated)", text: $metadataEditorDraft.genresText)
+                            TextField("Tags (comma-separated)", text: $metadataEditorDraft.tagsText)
+                        }
+                    }
+                } else {
+                    metadataCoverTab
                 }
             }
             .safeAreaInset(edge: .bottom) {
@@ -3052,19 +3101,26 @@ struct ContentView: View {
                     Button("Quick Match") {
                         Task { await quickMatchFromMetadataEditor() }
                     }
-                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil)
+                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil || metadataEditorTab != .details)
 
                     Button("Match…") {
                         openManualMetadataMatch()
                     }
-                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil)
+                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil || metadataEditorTab != .details)
 
                     Button("Re-Scan") {
                         if let itemID = resolvedMetadataEditorItemID() {
                             openMetadataEditor(for: itemID)
                         }
                     }
-                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil)
+                    .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil || metadataEditorTab != .details)
+
+                    if metadataEditorTab == .cover {
+                        Button("Apply Cover") {
+                            Task { await applySelectedCoverFromMetadataEditor() }
+                        }
+                        .disabled(metadataEditorBusy || resolvedMetadataEditorItemID() == nil || metadataPendingCoverData == nil)
+                    }
 
                     Spacer()
 
@@ -3107,6 +3163,13 @@ struct ContentView: View {
             .sheet(isPresented: $showingManualMetadataMatch) {
                 manualMetadataMatchSheet
             }
+            .fileImporter(
+                isPresented: $showingMetadataCoverFileImporter,
+                allowedContentTypes: [.image],
+                allowsMultipleSelection: false
+            ) { result in
+                handleMetadataCoverImport(result: result)
+            }
         }
         .frame(minWidth: 760, minHeight: 560)
     }
@@ -3116,12 +3179,188 @@ struct ContentView: View {
         return manualMetadataMatchCandidates.first(where: { $0.id == manualMetadataMatchSelectedCandidateID })
     }
 
+    private var selectedMetadataCoverResult: AppViewModel.CoverSearchResult? {
+        guard let metadataSelectedCoverResultID else { return nil }
+        return metadataCoverSearchResults.first(where: { $0.id == metadataSelectedCoverResultID })
+    }
+
+    private var metadataCurrentCoverImage: NSImage? {
+        if let metadataPendingCoverImage {
+            return metadataPendingCoverImage
+        }
+        guard let itemID = resolvedMetadataEditorItemID() else { return nil }
+        return coverImagesByItemID[itemID]
+    }
+
+    private var metadataCoverTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 14) {
+                    Group {
+                        if let image = metadataCurrentCoverImage {
+                            Image(nsImage: image)
+                                .resizable()
+                                .scaledToFit()
+                        } else {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.secondary.opacity(0.2))
+                                .overlay {
+                                    Image(systemName: "photo")
+                                        .font(.system(size: 24, weight: .semibold))
+                                        .foregroundStyle(.secondary)
+                                }
+                        }
+                    }
+                    .frame(width: 140, height: 140)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        if let image = metadataCurrentCoverImage {
+                            Text("\(Int(image.size.width))×\(Int(image.size.height))px")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("No cover selected")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        HStack(spacing: 8) {
+                            Button("Upload Cover") {
+                                showingMetadataCoverFileImporter = true
+                            }
+                            .disabled(metadataEditorBusy)
+
+                            TextField("Image URL from the web", text: $metadataCoverURLText)
+                                .textFieldStyle(.roundedBorder)
+
+                            Button("Use URL") {
+                                Task { await applyCoverURLToPendingSelection() }
+                            }
+                            .disabled(metadataEditorBusy || metadataCoverURLText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                }
+
+                Divider()
+
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Provider")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Picker("Provider", selection: .constant("Audible.com")) {
+                            Text("Audible.com").tag("Audible.com")
+                        }
+                        .labelsHidden()
+                        .frame(width: 150)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Search Title or ASIN")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        TextField("Title or ASIN", text: $metadataCoverSearchTitle)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: .infinity)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Author")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        TextField("Author", text: $metadataCoverSearchAuthor)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 220)
+                    }
+
+                    Button("Search") {
+                        Task { await runMetadataCoverSearch() }
+                    }
+                    .disabled(metadataEditorBusy || metadataCoverSearchBusy || metadataCoverSearchTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+
+                if metadataCoverSearchBusy {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Searching Audible covers…")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !metadataCoverSearchResults.isEmpty {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 130), spacing: 12)], spacing: 12) {
+                        ForEach(metadataCoverSearchResults) { result in
+                            metadataCoverSearchResultCard(result)
+                        }
+                    }
+                } else if !metadataCoverSearchBusy {
+                    Text("No search results yet.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    private func metadataCoverSearchResultCard(_ result: AppViewModel.CoverSearchResult) -> some View {
+        Button {
+            metadataSelectedCoverResultID = result.id
+            Task { await setPendingCover(from: result.imageURL) }
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                AsyncImage(url: result.imageURL) { phase in
+                    switch phase {
+                    case .empty:
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.secondary.opacity(0.15))
+                            .overlay { ProgressView() }
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFit()
+                    case .failure:
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.secondary.opacity(0.15))
+                            .overlay {
+                                Image(systemName: "photo")
+                                    .foregroundStyle(.secondary)
+                            }
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+                .frame(height: 160)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                Text(result.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(2)
+                if !result.authors.isEmpty {
+                    Text(result.authors.joined(separator: ", "))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(metadataSelectedCoverResultID == result.id ? Color.accentColor : Color.secondary.opacity(0.25), lineWidth: metadataSelectedCoverResultID == result.id ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
     private var manualMetadataMatchSheet: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 12) {
                 manualMetadataMatchSearchRow
                 manualMetadataMatchStatusRow
                 manualMetadataMatchCandidateList
+                manualMetadataPreviewSection
             }
             .padding(12)
             .navigationTitle("Match Metadata")
@@ -3175,7 +3414,132 @@ struct ContentView: View {
             List(manualMetadataMatchCandidates) { candidate in
                 manualMetadataMatchCandidateRow(candidate)
             }
+            .frame(minHeight: 180)
         }
+    }
+
+    @ViewBuilder
+    private var manualMetadataPreviewSection: some View {
+        if let candidate = selectedManualMetadataMatchCandidate,
+           let itemID = resolvedMetadataEditorItemID(),
+           let localItem = viewModel.item(withID: itemID) {
+            let changed = metadataChangedFields(local: localItem, candidate: candidate)
+            VStack(alignment: .leading, spacing: 8) {
+                Divider()
+                Text("Metadata Preview")
+                    .font(.headline)
+                if changed.isEmpty {
+                    Text("No metadata changes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Changed Fields: \(changed.joined(separator: ", "))")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.orange)
+                }
+                HStack(alignment: .top, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Current")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        metadataPreviewRow(label: "Title", value: localItem.title)
+                        metadataPreviewRow(label: "Authors", value: displayAuthorNames(for: localItem).joined(separator: ", "))
+                        metadataPreviewRow(label: "Narrator", value: preferredNarrator(for: localItem))
+                        metadataPreviewRow(label: "Series", value: localItem.seriesName)
+                        metadataPreviewRow(label: "Series #", value: localItem.seriesSequence.map(String.init))
+                        metadataPreviewRow(label: "Year", value: localItem.publishedYear.map(String.init))
+                        metadataPreviewRow(label: "Publisher", value: localItem.publisher)
+                        metadataPreviewRow(label: "Language", value: localItem.language)
+                        metadataPreviewRow(label: "Genres", value: localItem.genres.joined(separator: ", "))
+                        metadataPreviewRow(label: "Tags", value: localItem.tags.joined(separator: ", "))
+                        metadataPreviewRow(label: "Duration", value: formattedDuration(localItem.duration))
+                    }
+                    Divider()
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Matched (\(candidate.source))")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        metadataPreviewRow(label: "Title", value: candidate.title)
+                        metadataPreviewRow(label: "Authors", value: candidate.authors.joined(separator: ", "))
+                        metadataPreviewRow(label: "Narrator", value: candidate.narrator)
+                        metadataPreviewRow(label: "Series", value: candidate.seriesName)
+                        metadataPreviewRow(label: "Series #", value: candidate.seriesSequence.map(String.init))
+                        metadataPreviewRow(label: "Year", value: candidate.publishedYear.map(String.init))
+                        metadataPreviewRow(label: "Publisher", value: candidate.publisher)
+                        metadataPreviewRow(label: "Language", value: candidate.language)
+                        metadataPreviewRow(label: "Genres", value: candidate.genres.joined(separator: ", "))
+                        metadataPreviewRow(label: "Tags", value: candidate.tags.joined(separator: ", "))
+                        metadataPreviewRow(label: "Duration", value: formattedDuration(candidate.durationSeconds))
+                    }
+                }
+                if candidate.isExactRuntimeMatch {
+                    Text("Exact Match: runtime is within 1% of local duration.")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.green)
+                }
+            }
+        }
+    }
+
+    private func metadataPreviewRow(label: String, value: String?) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text("\(label):")
+                .foregroundStyle(.secondary)
+            Text((value?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? value! : "—")
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
+        .font(.caption)
+    }
+
+    private func metadataChangedFields(local: ABSCore.LibraryItem, candidate: MetadataMatchCandidate) -> [String] {
+        var fields: [String] = []
+
+        if normalizedScalar(local.title) != normalizedScalar(candidate.title) {
+            fields.append("Title")
+        }
+        if normalizedScalar(local.author ?? local.authors.first) != normalizedScalar(candidate.authors.first) {
+            fields.append("Author")
+        }
+        if normalizedList(local.authors) != normalizedList(candidate.authors) {
+            fields.append("Authors")
+        }
+        if normalizedScalar(local.narrator) != normalizedScalar(candidate.narrator) {
+            fields.append("Narrator")
+        }
+        if normalizedScalar(local.seriesName) != normalizedScalar(candidate.seriesName) {
+            fields.append("Series")
+        }
+        if local.seriesSequence != candidate.seriesSequence {
+            fields.append("Series #")
+        }
+        if local.publishedYear != candidate.publishedYear {
+            fields.append("Year")
+        }
+        if normalizedScalar(local.publisher) != normalizedScalar(candidate.publisher) {
+            fields.append("Publisher")
+        }
+        if normalizedScalar(local.language) != normalizedScalar(candidate.language) {
+            fields.append("Language")
+        }
+        if normalizedList(local.genres) != normalizedList(candidate.genres) {
+            fields.append("Genres")
+        }
+        if normalizedList(local.tags) != normalizedList(candidate.tags) {
+            fields.append("Tags")
+        }
+
+        return fields
+    }
+
+    private func normalizedScalar(_ value: String?) -> String {
+        value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    }
+
+    private func normalizedList(_ values: [String]) -> [String] {
+        values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
     }
 
     private func manualMetadataMatchCandidateRow(_ candidate: MetadataMatchCandidate) -> some View {
@@ -3195,6 +3559,11 @@ struct ContentView: View {
                     Text(candidate.confidenceReason)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                    if candidate.isExactRuntimeMatch {
+                        Text("Exact Match")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.green)
+                    }
                 }
                 Spacer()
                 Text("\(Int((candidate.confidence * 100).rounded()))%")
@@ -3213,6 +3582,14 @@ struct ContentView: View {
         guard let item = viewModel.item(withID: itemID) else { return }
         metadataEditorItemID = itemID
         metadataEditorDraft = metadataEditorDraft(from: item)
+        metadataEditorTab = .details
+        metadataCoverSearchTitle = item.title
+        metadataCoverSearchAuthor = displayAuthorNames(for: item).first ?? ""
+        metadataCoverSearchResults = []
+        metadataSelectedCoverResultID = nil
+        metadataPendingCoverData = nil
+        metadataPendingCoverImage = nil
+        metadataCoverURLText = ""
         metadataEditorErrorMessage = nil
         showingMetadataEditor = true
     }
@@ -3296,7 +3673,8 @@ struct ContentView: View {
         do {
             let didApply = try await viewModel.applyLocalMetadataCandidate(itemID: itemID, candidate: candidate)
             guard didApply else {
-                metadataEditorErrorMessage = "Selected match did not change metadata."
+                showingManualMetadataMatch = false
+                metadataEditorErrorMessage = "No metadata changes were needed. The selected match is already reflected in this item."
                 return
             }
             if let refreshed = viewModel.item(withID: itemID) {
@@ -3334,6 +3712,100 @@ struct ContentView: View {
             }
         } catch {
             metadataEditorErrorMessage = "Failed saving metadata: \(viewModel.describeError(error))"
+        }
+    }
+
+    private func runMetadataCoverSearch() async {
+        let title = metadataCoverSearchTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        let author = metadataCoverSearchAuthor.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        metadataCoverSearchBusy = true
+        defer { metadataCoverSearchBusy = false }
+
+        do {
+            let results = try await viewModel.searchAudibleCovers(
+                title: title,
+                author: author.isEmpty ? nil : author,
+                limit: 24
+            )
+            metadataCoverSearchResults = results
+            metadataSelectedCoverResultID = results.first?.id
+            if let first = results.first {
+                await setPendingCover(from: first.imageURL)
+            }
+            if results.isEmpty {
+                metadataEditorErrorMessage = "No Audible cover results found."
+            }
+        } catch {
+            metadataEditorErrorMessage = "Cover search failed: \(viewModel.describeError(error))"
+        }
+    }
+
+    private func setPendingCover(from url: URL) async {
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                metadataEditorErrorMessage = "Cover image download failed."
+                return
+            }
+            guard let image = NSImage(data: data) else {
+                metadataEditorErrorMessage = "Downloaded cover image is invalid."
+                return
+            }
+            metadataPendingCoverData = data
+            metadataPendingCoverImage = image
+        } catch {
+            metadataEditorErrorMessage = "Cover image download failed: \(viewModel.describeError(error))"
+        }
+    }
+
+    private func applyCoverURLToPendingSelection() async {
+        let text = metadataCoverURLText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: text), ["http", "https"].contains(url.scheme?.lowercased() ?? "") else {
+            metadataEditorErrorMessage = "Enter a valid HTTP(S) image URL."
+            return
+        }
+        await setPendingCover(from: url)
+    }
+
+    private func handleMetadataCoverImport(result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            do {
+                let data = try Data(contentsOf: url)
+                guard let image = NSImage(data: data) else {
+                    metadataEditorErrorMessage = "Selected file is not a valid image."
+                    return
+                }
+                metadataPendingCoverData = data
+                metadataPendingCoverImage = image
+            } catch {
+                metadataEditorErrorMessage = "Failed reading selected image: \(viewModel.describeError(error))"
+            }
+        case .failure(let error):
+            metadataEditorErrorMessage = "Cover import failed: \(viewModel.describeError(error))"
+        }
+    }
+
+    private func applySelectedCoverFromMetadataEditor() async {
+        guard let itemID = resolvedMetadataEditorItemID(),
+              let coverData = metadataPendingCoverData else { return }
+        metadataEditorBusy = true
+        defer { metadataEditorBusy = false }
+
+        do {
+            let didChange = try await viewModel.updateLocalItemCover(itemID: itemID, coverData: coverData)
+            if !didChange {
+                metadataEditorErrorMessage = "Selected cover is already applied."
+                return
+            }
+            if let image = NSImage(data: coverData) {
+                coverImagesByItemID[itemID] = image
+            }
+        } catch {
+            metadataEditorErrorMessage = "Failed applying cover: \(viewModel.describeError(error))"
         }
     }
 
@@ -3387,13 +3859,29 @@ struct ContentView: View {
         let stripPatterns = [
             #"(?i)\s*#\s*\d+\s*(,.*)?$"#,
             #"(?i)\s*\(\s*#\s*\d+\s*\)\s*$"#,
-            #"(?i)\s*,\s*book\s*\d+\s*$"#
+            #"(?i)\s*,\s*book\s*\d+\s*$"#,
+            // "Series Name 1: Book Title"
+            #"(?i)^(.+?)\s+\d+\s*:\s*.+$"#,
+            // "Series Name, Book 1: Book Title"
+            #"(?i)^(.+?)\s*,\s*book\s*\d+\s*:\s*.+$"#,
+            // "Series Name Book 1"
+            #"(?i)^(.+?)\s+book\s*\d+\s*$"#,
+            // "Series Name Vol 1"
+            #"(?i)^(.+?)\s+vol(?:ume)?\s*\d+\s*$"#
         ]
         for pattern in stripPatterns {
             guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
             let range = NSRange(value.startIndex..<value.endIndex, in: value)
-            value = regex.stringByReplacingMatches(in: value, options: [], range: range, withTemplate: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if pattern.contains("^(.+?)") {
+                if let match = regex.firstMatch(in: value, options: [], range: range),
+                   match.numberOfRanges > 1,
+                   let captured = Range(match.range(at: 1), in: value) {
+                    value = value[captured].trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            } else {
+                value = regex.stringByReplacingMatches(in: value, options: [], range: range, withTemplate: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
         }
 
         return value.isEmpty ? "Unknown Series" : value
@@ -4135,6 +4623,66 @@ struct ContentView: View {
 
     private func detailRow(title: String, value: String) -> some View {
         detailRow(title: title, value: value, multiline: false)
+    }
+
+    @ViewBuilder
+    private func editionBadge(for item: ABSCore.LibraryItem) -> some View {
+        switch editionVariant(for: item) {
+        case .dramatized:
+            Text("Dramatized")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.orange)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.orange.opacity(0.15))
+                )
+        case .standard:
+            Text("Standard")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.secondary.opacity(0.12))
+                )
+        }
+    }
+
+    private enum EditionVariant {
+        case standard
+        case dramatized
+    }
+
+    private func editionVariant(for item: ABSCore.LibraryItem) -> EditionVariant {
+        let signals = [
+            item.title,
+            item.blurb ?? "",
+            preferredNarrator(for: item) ?? "",
+            item.author ?? "",
+            item.authors.joined(separator: " "),
+            item.tags.joined(separator: " "),
+            item.genres.joined(separator: " "),
+            item.collections.joined(separator: " ")
+        ].joined(separator: " ").lowercased()
+
+        let dramatizedCues = [
+            "dramatized",
+            "dramatised",
+            "dramatic adaptation",
+            "dramatized adaptation",
+            "audio drama",
+            "full cast",
+            "graphicaudio",
+            "graphic audio"
+        ]
+
+        if dramatizedCues.contains(where: { signals.contains($0) }) {
+            return .dramatized
+        }
+        return .standard
     }
 
     private func detailRow(title: String, value: String, multiline: Bool) -> some View {

--- a/Sources/ABSClientMac/LocalLibraryManager.swift
+++ b/Sources/ABSClientMac/LocalLibraryManager.swift
@@ -195,6 +195,90 @@ actor LocalLibraryManager {
     }
 
     @discardableResult
+    func ingestCopiedFile(
+        rootID: String,
+        fileURL: URL,
+        sourceItem: ABSCore.LibraryItem
+    ) async throws -> Bool {
+        guard state.roots.contains(where: { $0.id == rootID }) else {
+            return false
+        }
+        let standardizedFileURL = fileURL.standardizedFileURL
+        guard fileManager.fileExists(atPath: standardizedFileURL.path) else {
+            return false
+        }
+
+        let metadata = await extractMetadata(from: standardizedFileURL)
+        let fallbackTitle = standardizedFileURL.deletingPathExtension().lastPathComponent
+        let extractedTitle = metadata.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let localLibraryID = Self.libraryIDPrefix + rootID
+        let itemID = "local-item:\(Self.hash(standardizedFileURL.path))"
+
+        let scannedBaseline = ABSCore.LibraryItem(
+            id: itemID,
+            title: (extractedTitle?.isEmpty == false) ? extractedTitle! : fallbackTitle,
+            author: metadata.author,
+            authors: metadata.authors,
+            narrator: metadata.narrator,
+            seriesName: metadata.seriesName,
+            seriesSequence: metadata.seriesSequence,
+            collections: [],
+            genres: [],
+            tags: [],
+            blurb: nil,
+            publisher: nil,
+            publishedYear: nil,
+            language: nil,
+            libraryID: localLibraryID,
+            duration: metadata.duration,
+            chapters: metadata.chapters
+        )
+
+        let overlaid = ABSCore.LibraryItem(
+            id: itemID,
+            title: preferredTitle(primary: sourceItem.title, fallback: scannedBaseline.title),
+            author: preferredScalar(sourceItem.author, fallback: scannedBaseline.author ?? sourceItem.authors.first),
+            authors: sourceItem.authors.isEmpty ? scannedBaseline.authors : sourceItem.authors,
+            narrator: preferredScalar(sourceItem.narrator, fallback: scannedBaseline.narrator),
+            seriesName: preferredScalar(sourceItem.seriesName, fallback: scannedBaseline.seriesName),
+            seriesSequence: sourceItem.seriesSequence ?? scannedBaseline.seriesSequence,
+            collections: sourceItem.collections,
+            genres: sourceItem.genres,
+            tags: sourceItem.tags,
+            blurb: preferredScalar(sourceItem.blurb, fallback: scannedBaseline.blurb),
+            publisher: preferredScalar(sourceItem.publisher, fallback: scannedBaseline.publisher),
+            publishedYear: sourceItem.publishedYear ?? scannedBaseline.publishedYear,
+            language: preferredScalar(sourceItem.language, fallback: scannedBaseline.language),
+            libraryID: localLibraryID,
+            duration: sourceItem.duration ?? scannedBaseline.duration,
+            chapters: sourceItem.chapters.isEmpty ? scannedBaseline.chapters : sourceItem.chapters
+        )
+
+        var items = state.itemsByRootID[rootID] ?? []
+        if let index = items.firstIndex(where: { $0.primaryFilePath == standardizedFileURL.path || $0.item.id == itemID }) {
+            let existing = items[index]
+            let merged = mergedScannedItem(existing: existing.item, scanned: overlaid)
+            items[index] = PersistedItem(
+                item: merged,
+                primaryFilePath: standardizedFileURL.path,
+                coverData: existing.coverData ?? metadata.coverData
+            )
+        } else {
+            items.append(
+                PersistedItem(
+                    item: overlaid,
+                    primaryFilePath: standardizedFileURL.path,
+                    coverData: metadata.coverData
+                )
+            )
+        }
+
+        state.itemsByRootID[rootID] = items.sorted { $0.item.title.localizedCaseInsensitiveCompare($1.item.title) == .orderedAscending }
+        try persist()
+        return true
+    }
+
+    @discardableResult
     func applyMetadataCandidate(
         rootID: String,
         itemID: String,
@@ -251,6 +335,36 @@ actor LocalLibraryManager {
         return true
     }
 
+    @discardableResult
+    func updateItemCoverData(
+        rootID: String,
+        itemID: String,
+        coverData: Data?
+    ) throws -> Bool {
+        guard var items = state.itemsByRootID[rootID] else {
+            return false
+        }
+        guard let itemIndex = items.firstIndex(where: { $0.item.id == itemID }) else {
+            return false
+        }
+
+        let existingRecord = items[itemIndex]
+        let existingCover = existingRecord.coverData ?? Data()
+        let incomingCover = coverData ?? Data()
+        guard existingCover != incomingCover else {
+            return false
+        }
+
+        items[itemIndex] = PersistedItem(
+            item: existingRecord.item,
+            primaryFilePath: existingRecord.primaryFilePath,
+            coverData: coverData
+        )
+        state.itemsByRootID[rootID] = items
+        try persist()
+        return true
+    }
+
     private func scanRoot(_ root: PersistedRoot) async throws -> [PersistedItem] {
         let rootURL = URL(fileURLWithPath: root.directoryPath, isDirectory: true)
         guard fileManager.fileExists(atPath: rootURL.path) else {
@@ -269,6 +383,9 @@ actor LocalLibraryManager {
         )
 
         var persistedItems: [PersistedItem] = []
+        let existingByPath = Dictionary(
+            uniqueKeysWithValues: (state.itemsByRootID[root.id] ?? []).map { ($0.primaryFilePath, $0) }
+        )
 
         for (groupKey, files) in grouped {
             guard let primary = files.max(by: { Self.fileSize(of: $0, fileManager: fileManager) < Self.fileSize(of: $1, fileManager: fileManager) }) else {
@@ -309,11 +426,15 @@ actor LocalLibraryManager {
                 chapters: metadata.chapters
             )
 
+            let mergedItem = existingByPath[primary.path].map { existing in
+                mergedScannedItem(existing: existing.item, scanned: item)
+            } ?? item
+
             persistedItems.append(
                 PersistedItem(
-                    item: item,
+                    item: mergedItem,
                     primaryFilePath: primary.path,
-                    coverData: metadata.coverData
+                    coverData: existingByPath[primary.path]?.coverData ?? metadata.coverData
                 )
             )
         }
@@ -455,6 +576,37 @@ actor LocalLibraryManager {
             return (name.isEmpty ? value : name, sequence)
         }
 
+        let patterns: [String] = [
+            // "Series Name 1: Book Title"
+            #"(?i)^\s*(.+?)\s+(\d+)\s*:\s*.+$"#,
+            // "Series Name, Book 1: Book Title"
+            #"(?i)^\s*(.+?)\s*,\s*book\s+(\d+)\s*:\s*.+$"#,
+            // "Series Name Book 1"
+            #"(?i)^\s*(.+?)\s+book\s+(\d+)\s*$"#,
+            // "Series Name Vol 1"
+            #"(?i)^\s*(.+?)\s+vol(?:ume)?\s+(\d+)\s*$"#
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(value.startIndex..<value.endIndex, in: value)
+            guard let match = regex.firstMatch(in: value, options: [], range: range), match.numberOfRanges > 2 else {
+                continue
+            }
+            let name: String? = {
+                guard let r = Range(match.range(at: 1), in: value) else { return nil }
+                let parsed = value[r].trimmingCharacters(in: .whitespacesAndNewlines)
+                return parsed.isEmpty ? nil : parsed
+            }()
+            let sequence: Int? = {
+                guard let r = Range(match.range(at: 2), in: value) else { return nil }
+                return Int(value[r])
+            }()
+            if let name {
+                return (name, sequence)
+            }
+        }
+
         return (value, nil)
     }
 
@@ -497,21 +649,36 @@ actor LocalLibraryManager {
     }
 
     private func mergedItem(existing: ABSCore.LibraryItem, candidate: MetadataMatchCandidate) -> ABSCore.LibraryItem {
-        ABSCore.LibraryItem(
+        let candidateTitle = candidate.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = candidateTitle.isEmpty ? existing.title : candidateTitle
+        let resolvedAuthors = candidate.authors
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let resolvedAuthor = resolvedAuthors.first
+        let resolvedNarrator = candidate.narrator?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedSeries = candidate.seriesName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedCollections = normalizedList(candidate.collections)
+        let resolvedGenres = normalizedList(candidate.genres)
+        let resolvedTags = normalizedList(candidate.tags)
+        let resolvedBlurb = candidate.blurb?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedPublisher = candidate.publisher?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedLanguage = candidate.language?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return ABSCore.LibraryItem(
             id: existing.id,
-            title: shouldReplaceScalar(existing.title) ? candidate.title : existing.title,
-            author: mergeScalar(existing.author, fallback: candidate.authors.first),
-            authors: mergeArray(existing.authors, fallback: candidate.authors),
-            narrator: mergeScalar(existing.narrator, fallback: candidate.narrator),
-            seriesName: mergeScalar(existing.seriesName, fallback: candidate.seriesName),
-            seriesSequence: existing.seriesSequence ?? candidate.seriesSequence,
-            collections: mergeArray(existing.collections, fallback: candidate.collections),
-            genres: mergeArray(existing.genres, fallback: candidate.genres),
-            tags: mergeArray(existing.tags, fallback: candidate.tags),
-            blurb: mergeScalar(existing.blurb, fallback: candidate.blurb),
-            publisher: mergeScalar(existing.publisher, fallback: candidate.publisher),
-            publishedYear: existing.publishedYear ?? candidate.publishedYear,
-            language: mergeScalar(existing.language, fallback: candidate.language),
+            title: resolvedTitle,
+            author: resolvedAuthor,
+            authors: resolvedAuthors,
+            narrator: resolvedNarrator?.isEmpty == false ? resolvedNarrator : nil,
+            seriesName: resolvedSeries?.isEmpty == false ? resolvedSeries : nil,
+            seriesSequence: candidate.seriesSequence,
+            collections: resolvedCollections,
+            genres: resolvedGenres,
+            tags: resolvedTags,
+            blurb: resolvedBlurb?.isEmpty == false ? resolvedBlurb : nil,
+            publisher: resolvedPublisher?.isEmpty == false ? resolvedPublisher : nil,
+            publishedYear: candidate.publishedYear,
+            language: resolvedLanguage?.isEmpty == false ? resolvedLanguage : nil,
             libraryID: existing.libraryID,
             duration: existing.duration,
             chapters: existing.chapters
@@ -545,5 +712,60 @@ actor LocalLibraryManager {
             }
         }
         return merged
+    }
+
+    private func normalizedList(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for raw in values {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.lowercased()
+            if seen.insert(key).inserted {
+                result.append(trimmed)
+            }
+        }
+        return result
+    }
+
+    private func preferredScalar(_ primary: String?, fallback: String?) -> String? {
+        if let primary, !primary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return primary.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let fallback, !fallback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private func preferredTitle(primary: String, fallback: String) -> String {
+        let trimmedPrimary = primary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedPrimary.isEmpty, trimmedPrimary.caseInsensitiveCompare("Unknown Title") != .orderedSame {
+            return trimmedPrimary
+        }
+        let trimmedFallback = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedFallback.isEmpty ? "Unknown Title" : trimmedFallback
+    }
+
+    private func mergedScannedItem(existing: ABSCore.LibraryItem, scanned: ABSCore.LibraryItem) -> ABSCore.LibraryItem {
+        ABSCore.LibraryItem(
+            id: scanned.id,
+            title: shouldReplaceScalar(existing.title) ? scanned.title : existing.title,
+            author: mergeScalar(existing.author, fallback: scanned.author),
+            authors: mergeArray(existing.authors, fallback: scanned.authors),
+            narrator: mergeScalar(existing.narrator, fallback: scanned.narrator),
+            seriesName: mergeScalar(existing.seriesName, fallback: scanned.seriesName),
+            seriesSequence: existing.seriesSequence ?? scanned.seriesSequence,
+            collections: mergeArray(existing.collections, fallback: scanned.collections),
+            genres: mergeArray(existing.genres, fallback: scanned.genres),
+            tags: mergeArray(existing.tags, fallback: scanned.tags),
+            blurb: mergeScalar(existing.blurb, fallback: scanned.blurb),
+            publisher: mergeScalar(existing.publisher, fallback: scanned.publisher),
+            publishedYear: existing.publishedYear ?? scanned.publishedYear,
+            language: mergeScalar(existing.language, fallback: scanned.language),
+            libraryID: scanned.libraryID,
+            duration: scanned.duration ?? existing.duration,
+            chapters: scanned.chapters.isEmpty ? existing.chapters : scanned.chapters
+        )
     }
 }

--- a/Sources/ABSClientMac/MetadataMatcher.swift
+++ b/Sources/ABSClientMac/MetadataMatcher.swift
@@ -19,6 +19,8 @@ struct MetadataMatchCandidate: Identifiable, Hashable, Sendable {
     let publisher: String?
     let publishedYear: Int?
     let language: String?
+    let durationSeconds: TimeInterval?
+    let isExactRuntimeMatch: Bool
 }
 
 actor OpenLibraryMetadataMatcher {
@@ -72,7 +74,25 @@ actor OpenLibraryMetadataMatcher {
             googleCandidate(from: volume, localItem: item, localTitle: queryTitle, localAuthors: localAuthors)
         }
 
-        return (openLibraryCandidates + googleCandidates)
+        let audibleProducts = try await audibleSearch(
+            queryTitle: queryTitle,
+            firstAuthor: localAuthors.first,
+            limit: max(1, min(limit * 2, 20))
+        )
+        let audibleCandidates = audibleProducts.compactMap { product in
+            audibleCandidate(from: product, localItem: item, localTitle: queryTitle, localAuthors: localAuthors)
+        }
+
+        let amazonItems = try await amazonSearch(
+            queryTitle: queryTitle,
+            firstAuthor: localAuthors.first,
+            limit: max(1, min(limit * 2, 20))
+        )
+        let amazonCandidates = amazonItems.compactMap { amazon in
+            amazonCandidate(from: amazon, localItem: item, localTitle: queryTitle, localAuthors: localAuthors)
+        }
+
+        return deduplicatedCandidates(openLibraryCandidates + googleCandidates + audibleCandidates + amazonCandidates)
             .sorted { lhs, rhs in
                 if lhs.confidence == rhs.confidence {
                     return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
@@ -110,6 +130,69 @@ actor OpenLibraryMetadataMatcher {
 
         let decoded = try JSONDecoder().decode(GoogleBooksResponse.self, from: data)
         return decoded.items ?? []
+    }
+
+    private func audibleSearch(
+        queryTitle: String,
+        firstAuthor: String?,
+        limit: Int
+    ) async throws -> [AudibleCatalogResponse.Product] {
+        var queryParts = [queryTitle]
+        if let firstAuthor, !firstAuthor.isEmpty {
+            queryParts.append(firstAuthor)
+        }
+
+        var components = URLComponents(string: "https://api.audible.com/1.0/catalog/products")
+        components?.queryItems = [
+            URLQueryItem(name: "response_groups", value: "contributors,series,product_desc,product_attrs"),
+            URLQueryItem(name: "num_results", value: String(max(1, min(limit, 50)))),
+            URLQueryItem(name: "keywords", value: queryParts.joined(separator: " "))
+        ]
+        guard let url = components?.url else {
+            return []
+        }
+
+        let (data, response) = try await session.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            return []
+        }
+
+        let decoded = try JSONDecoder().decode(AudibleCatalogResponse.self, from: data)
+        return decoded.products ?? []
+    }
+
+    private func amazonSearch(
+        queryTitle: String,
+        firstAuthor: String?,
+        limit: Int
+    ) async throws -> [AmazonSearchItem] {
+        let query = [queryTitle, firstAuthor, "audiobook"].compactMap { $0 }.joined(separator: " ")
+        var components = URLComponents(string: "https://www.amazon.com/s")
+        components?.queryItems = [
+            URLQueryItem(name: "i", value: "audible"),
+            URLQueryItem(name: "k", value: query)
+        ]
+        guard let url = components?.url else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode),
+              let html = String(data: data, encoding: .utf8) else {
+            return []
+        }
+
+        if html.localizedCaseInsensitiveContains("To discuss automated access to Amazon data") {
+            return []
+        }
+        return parseAmazonSearchHTML(html, limit: limit)
     }
 
     private func search(queryItems: [URLQueryItem]) async throws -> [OpenLibrarySearchResponse.Document] {
@@ -180,7 +263,9 @@ actor OpenLibraryMetadataMatcher {
             blurb: document.firstSentence?.trimmingCharacters(in: .whitespacesAndNewlines),
             publisher: (publisher?.isEmpty == false) ? publisher : nil,
             publishedYear: document.firstPublishYear,
-            language: (language?.isEmpty == false) ? language : nil
+            language: (language?.isEmpty == false) ? language : nil,
+            durationSeconds: nil,
+            isExactRuntimeMatch: false
         )
     }
 
@@ -240,7 +325,123 @@ actor OpenLibraryMetadataMatcher {
             blurb: info.description?.trimmingCharacters(in: .whitespacesAndNewlines),
             publisher: info.publisher?.trimmingCharacters(in: .whitespacesAndNewlines),
             publishedYear: publishedYear(from: info.publishedDate),
-            language: (language?.isEmpty == false) ? language : nil
+            language: (language?.isEmpty == false) ? language : nil,
+            durationSeconds: nil,
+            isExactRuntimeMatch: false
+        )
+    }
+
+    private func audibleCandidate(
+        from product: AudibleCatalogResponse.Product,
+        localItem: ABSCore.LibraryItem,
+        localTitle: String,
+        localAuthors: [String]
+    ) -> MetadataMatchCandidate? {
+        let candidateTitle = normalizedCandidateTitle(product.title ?? "")
+        guard !candidateTitle.isEmpty else { return nil }
+
+        let candidateAuthors = (product.authors ?? [])
+            .compactMap { $0.name?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let candidateNarrators = (product.narrators ?? [])
+            .compactMap { $0.name?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let firstSeries = product.series?.first
+        let seriesName = normalizedCandidateTitle(firstSeries?.title ?? "")
+        let seriesSequence = Int(firstSeries?.sequence ?? "")
+        let candidateDurationSeconds = product.runtimeLengthMinutes.map { Double($0) * 60 }
+
+        let titleScore = titleSimilarity(localTitle, candidateTitle)
+        let authorScore: Double
+        if localAuthors.isEmpty {
+            authorScore = candidateAuthors.isEmpty ? 0.5 : 0.68
+        } else if candidateAuthors.isEmpty {
+            authorScore = 0.2
+        } else {
+            authorScore = localAuthors.map { local in
+                candidateAuthors.map { candidate in titleSimilarity(local, candidate) }.max() ?? 0
+            }.reduce(0, +) / Double(max(1, localAuthors.count))
+        }
+
+        let publishedYear = publishedYear(from: product.issueDate ?? product.releaseDate ?? product.publicationDatetime)
+        let yearScore = publicationYearScore(localItem.publishedYear, publishedYear)
+        let sequenceScore = sequenceAlignmentScore(localItem.seriesSequence, seriesSequence)
+        let runtimeScore = runtimeAlignmentScore(localItem.duration, candidateDurationSeconds)
+        let runtimeDelta = runtimeDifference(localItem.duration, candidateDurationSeconds)
+        let exactRuntimeMatch = (runtimeDelta ?? 1) <= 0.01
+        let confidence = max(0, min(1, (titleScore * 0.56) + (authorScore * 0.23) + (yearScore * 0.07) + (sequenceScore * 0.04) + (runtimeScore * 0.10)))
+        guard confidence >= 0.5 else { return nil }
+
+        return MetadataMatchCandidate(
+            id: UUID().uuidString,
+            source: "Audible",
+            sourceID: product.asin,
+            confidence: confidence,
+            confidenceReason: "title \(percent(titleScore)), author \(percent(authorScore)), year \(percent(yearScore)), sequence \(percent(sequenceScore)), runtime \(percent(runtimeScore))",
+            title: candidateTitle,
+            authors: candidateAuthors,
+            narrator: candidateNarrators.joined(separator: ", "),
+            seriesName: seriesName.isEmpty ? nil : seriesName,
+            seriesSequence: seriesSequence,
+            collections: [],
+            genres: [],
+            tags: [],
+            blurb: stripHTMLTags(product.merchandisingSummary),
+            publisher: product.publisherName?.trimmingCharacters(in: .whitespacesAndNewlines),
+            publishedYear: publishedYear,
+            language: normalizedLanguage(product.language),
+            durationSeconds: candidateDurationSeconds,
+            isExactRuntimeMatch: exactRuntimeMatch
+        )
+    }
+
+    private func amazonCandidate(
+        from amazon: AmazonSearchItem,
+        localItem: ABSCore.LibraryItem,
+        localTitle: String,
+        localAuthors: [String]
+    ) -> MetadataMatchCandidate? {
+        let candidateTitle = normalizedCandidateTitle(amazon.title)
+        guard !candidateTitle.isEmpty else { return nil }
+
+        let candidateAuthors = normalizedUnique(amazon.authors, limit: 5)
+        let titleScore = titleSimilarity(localTitle, candidateTitle)
+        let authorScore: Double
+        if localAuthors.isEmpty {
+            authorScore = candidateAuthors.isEmpty ? 0.5 : 0.65
+        } else if candidateAuthors.isEmpty {
+            // Amazon result cards sometimes omit author in scrapeable text.
+            authorScore = 0.35
+        } else {
+            authorScore = localAuthors.map { local in
+                candidateAuthors.map { candidate in titleSimilarity(local, candidate) }.max() ?? 0
+            }.reduce(0, +) / Double(max(1, localAuthors.count))
+        }
+        let yearScore = publicationYearScore(localItem.publishedYear, amazon.publishedYear)
+        let sequenceScore = sequenceAlignmentScore(localItem.seriesSequence, sequenceFromText(candidateTitle))
+        let confidence = max(0, min(1, (titleScore * 0.66) + (authorScore * 0.24) + (yearScore * 0.06) + (sequenceScore * 0.04)))
+        guard confidence >= 0.53 else { return nil }
+
+        return MetadataMatchCandidate(
+            id: UUID().uuidString,
+            source: "Amazon",
+            sourceID: amazon.asin,
+            confidence: confidence,
+            confidenceReason: "title \(percent(titleScore)), author \(percent(authorScore)), year \(percent(yearScore)), sequence \(percent(sequenceScore))",
+            title: candidateTitle,
+            authors: candidateAuthors,
+            narrator: nil,
+            seriesName: nil,
+            seriesSequence: nil,
+            collections: [],
+            genres: [],
+            tags: [],
+            blurb: nil,
+            publisher: nil,
+            publishedYear: amazon.publishedYear,
+            language: nil,
+            durationSeconds: nil,
+            isExactRuntimeMatch: false
         )
     }
 
@@ -330,6 +531,22 @@ actor OpenLibraryMetadataMatcher {
         return localSequence == candidateSequence ? 1 : 0
     }
 
+    private func runtimeDifference(_ localDuration: TimeInterval?, _ candidateDuration: TimeInterval?) -> Double? {
+        guard let localDuration, let candidateDuration, localDuration > 0, candidateDuration > 0 else { return nil }
+        return abs(localDuration - candidateDuration) / candidateDuration
+    }
+
+    private func runtimeAlignmentScore(_ localDuration: TimeInterval?, _ candidateDuration: TimeInterval?) -> Double {
+        guard let delta = runtimeDifference(localDuration, candidateDuration) else { return 0.5 }
+        switch delta {
+        case ...0.01: return 1.0
+        case ...0.03: return 0.85
+        case ...0.05: return 0.7
+        case ...0.10: return 0.45
+        default: return 0.1
+        }
+    }
+
     private func sequenceFromText(_ text: String) -> Int? {
         let patterns = [
             "#\\s*(\\d+)",
@@ -409,6 +626,130 @@ actor OpenLibraryMetadataMatcher {
         guard trimmed.count >= 4 else { return nil }
         let prefix = String(trimmed.prefix(4))
         return Int(prefix)
+    }
+
+    private func parseAmazonSearchHTML(_ html: String, limit: Int) -> [AmazonSearchItem] {
+        guard let blockRegex = try? NSRegularExpression(
+            pattern: #"<div[^>]*data-component-type=\"s-search-result\"[^>]*data-asin=\"([A-Z0-9]{8,14})\"[^>]*>([\s\S]*?)</div>\s*</div>"#,
+            options: [.caseInsensitive]
+        ) else {
+            return []
+        }
+
+        let nsRange = NSRange(html.startIndex..<html.endIndex, in: html)
+        let matches = blockRegex.matches(in: html, options: [], range: nsRange)
+        var items: [AmazonSearchItem] = []
+        var seen = Set<String>()
+        for match in matches {
+            guard match.numberOfRanges > 2,
+                  let asinRange = Range(match.range(at: 1), in: html),
+                  let blockRange = Range(match.range(at: 2), in: html) else {
+                continue
+            }
+            let asin = String(html[asinRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !asin.isEmpty else { continue }
+            let block = String(html[blockRange])
+            guard let title = firstRegexGroup(
+                in: block,
+                pattern: #"<h2[^>]*>[\s\S]*?<span[^>]*>(.*?)</span>"#,
+                options: [.caseInsensitive]
+            ) else {
+                continue
+            }
+
+            let normalizedTitle = decodeHTMLEntities(stripHTMLTags(title) ?? title)
+            guard !normalizedTitle.isEmpty else { continue }
+            let authors = extractAmazonAuthors(from: block)
+            let year = extractFirstYear(in: block)
+            let dedupeKey = "\(asin.lowercased())::\(normalizedTitle.lowercased())"
+            if seen.insert(dedupeKey).inserted {
+                items.append(AmazonSearchItem(asin: asin, title: normalizedTitle, authors: authors, publishedYear: year))
+            }
+            if items.count >= limit {
+                break
+            }
+        }
+        return items
+    }
+
+    private func extractAmazonAuthors(from block: String) -> [String] {
+        let bylineText = firstRegexGroup(
+            in: block,
+            pattern: #"(?:by|By)\s*</span>\s*<span[^>]*>(.*?)</span>"#,
+            options: [.caseInsensitive]
+        ) ?? firstRegexGroup(
+            in: block,
+            pattern: #"(?:by|By)\s+([^<\|]+)"#,
+            options: [.caseInsensitive]
+        )
+
+        guard let bylineText else { return [] }
+        let cleaned = decodeHTMLEntities(stripHTMLTags(bylineText) ?? bylineText)
+        return cleaned
+            .replacingOccurrences(of: "\\(.*?\\)", with: " ", options: .regularExpression)
+            .split(separator: ",")
+            .map { $0.replacingOccurrences(of: " and ", with: ",") }
+            .flatMap { $0.split(separator: ",") }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func extractFirstYear(in text: String) -> Int? {
+        guard let yearText = firstRegexGroup(in: text, pattern: #"\b((?:19|20)\d{2})\b"#, options: []) else {
+            return nil
+        }
+        return Int(yearText)
+    }
+
+    private func firstRegexGroup(
+        in text: String,
+        pattern: String,
+        options: NSRegularExpression.Options
+    ) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range), match.numberOfRanges > 1,
+              let valueRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return String(text[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func stripHTMLTags(_ html: String?) -> String? {
+        guard let html else { return nil }
+        let noTags = html.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+        let collapsed = noTags.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        let cleaned = decodeHTMLEntities(collapsed).trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private func decodeHTMLEntities(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+    }
+
+    private func deduplicatedCandidates(_ candidates: [MetadataMatchCandidate]) -> [MetadataMatchCandidate] {
+        var dedupedByKey: [String: MetadataMatchCandidate] = [:]
+        for candidate in candidates {
+            let firstAuthor = candidate.authors.first?.lowercased() ?? ""
+            let yearPart = candidate.publishedYear.map(String.init) ?? ""
+            let key = "\(candidate.title.lowercased())::\(firstAuthor)::\(yearPart)"
+            if let existing = dedupedByKey[key] {
+                if candidate.confidence > existing.confidence {
+                    dedupedByKey[key] = candidate
+                }
+            } else {
+                dedupedByKey[key] = candidate
+            }
+        }
+        return Array(dedupedByKey.values)
     }
 
     private func candidateKey(for doc: OpenLibrarySearchResponse.Document) -> String {
@@ -526,4 +867,56 @@ private struct GoogleBooksResponse: Decodable {
     }
 
     let items: [Volume]?
+}
+
+private struct AudibleCatalogResponse: Decodable {
+    struct Contributor: Decodable {
+        let name: String?
+    }
+
+    struct Series: Decodable {
+        let title: String?
+        let sequence: String?
+    }
+
+    struct Product: Decodable {
+        let asin: String?
+        let title: String?
+        let subtitle: String?
+        let authors: [Contributor]?
+        let narrators: [Contributor]?
+        let series: [Series]?
+        let publisherName: String?
+        let language: String?
+        let merchandisingSummary: String?
+        let issueDate: String?
+        let releaseDate: String?
+        let publicationDatetime: String?
+        let runtimeLengthMinutes: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case asin
+            case title
+            case subtitle
+            case authors
+            case narrators
+            case series
+            case publisherName = "publisher_name"
+            case language
+            case merchandisingSummary = "merchandising_summary"
+            case issueDate = "issue_date"
+            case releaseDate = "release_date"
+            case publicationDatetime = "publication_datetime"
+            case runtimeLengthMinutes = "runtime_length_min"
+        }
+    }
+
+    let products: [Product]?
+}
+
+private struct AmazonSearchItem {
+    let asin: String
+    let title: String
+    let authors: [String]
+    let publishedYear: Int?
 }

--- a/Sources/ABSClientMac/PreferencesView.swift
+++ b/Sources/ABSClientMac/PreferencesView.swift
@@ -249,7 +249,7 @@ struct PreferencesView: View {
                                     showMetadataMatchOptIn = true
                                 }
                                 .disabled(localLibraryLoading || localLibraryRescanInProgress || metadataMatchInProgress)
-                                .help("Find metadata matches from OpenLibrary. You review confidence and approve before apply.")
+                                .help("Find metadata matches from online providers. You review confidence and approve before apply.")
                             }
                         }
                         .padding(.vertical, 4)
@@ -276,7 +276,7 @@ struct PreferencesView: View {
                 metadataMatchingRoot = nil
             }
         } message: {
-            Text("Metadata matching uses OpenLibrary search queries. Matches are scored and require your review before any changes are applied.")
+            Text("Metadata matching uses online provider search queries. Matches are scored and require your review before any changes are applied.")
         }
         .sheet(isPresented: $showMetadataMatchReview) {
             metadataMatchReviewSheet
@@ -329,7 +329,7 @@ struct PreferencesView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Metadata Review")
                         .font(.title3.bold())
-                    Text("Source: OpenLibrary • Non-destructive merge")
+                    Text("Source: Online providers • Non-destructive merge")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -374,7 +374,7 @@ struct PreferencesView: View {
 
                             Picker("Candidate", selection: $review.selectedCandidateID) {
                                 ForEach(review.candidates) { candidate in
-                                    Text("\(candidate.title) • \(Int((candidate.confidence * 100).rounded()))%")
+                                    Text("\(candidate.title)\(candidate.isExactRuntimeMatch ? " • Exact Match" : "") • \(Int((candidate.confidence * 100).rounded()))%")
                                         .tag(candidate.id)
                                 }
                             }
@@ -382,9 +382,16 @@ struct PreferencesView: View {
                             .pickerStyle(.menu)
 
                             if let selected = review.selectedCandidate {
-                                Text("\(selected.authors.joined(separator: ", ")) • \(selected.confidenceReason)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 6) {
+                                    Text("\(selected.authors.joined(separator: ", ")) • \(selected.confidenceReason)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    if selected.isExactRuntimeMatch {
+                                        Text("Exact Match")
+                                            .font(.caption.weight(.semibold))
+                                            .foregroundStyle(.green)
+                                    }
+                                }
                             }
                         }
                         .padding(.vertical, 4)

--- a/docs/releases/v0.1.0-beta.5.md
+++ b/docs/releases/v0.1.0-beta.5.md
@@ -1,0 +1,41 @@
+# indexd v0.1.0-beta.5 (Pre-release)
+
+## Highlights
+
+- Added a local metadata matching workflow so local-library books can be reconciled and updated from the app.
+- Added local library folder watching with automatic refresh when items are added or changed.
+- Added template-based local library organization settings (including unmatched-item handling).
+- Improved local-library context actions so Finder opens the selected library root with clearer local wording.
+- Fixed multi-copy to local library reliability for queued/bulk operations.
+- Fixed series-folder duplication caused by ABS-style series suffixes like `#1`, `#2`.
+
+## Full Changelog
+
+### Added
+- Local metadata matching and reconciliation workflow:
+  - Per-book metadata editor from item actions.
+  - Match actions and reconciliation support for local-library metadata updates.
+- Local library auto-refresh via file-system watching:
+  - Monitors library folders (including subfolders) for changes.
+  - Triggers automatic library updates when new or changed items are detected.
+- Local library file-organization settings:
+  - Template-based organization under library root (for example `Author/Series/Book`).
+  - Unmatched-item fallback handling for organization workflows.
+
+### Changed
+- Local-library context actions now open the configured local library root in Finder.
+- Local-library menu labeling was clarified to reduce confusion with remote download wording.
+- README release instructions were simplified by removing outdated notarization references.
+
+### Fixed
+- Multi-item copy to local library was hardened to avoid follow-on failures in queued operations.
+- Series normalization now strips ABS-style trailing sequence suffixes (for example `Series #1`) during folder resolution to prevent duplicate per-book series directories.
+
+### Included Commits
+- `34f9884` feat(local): add metadata matching workflow and reconciliation notes (#27)
+- `c9b21c2` feat(local): watch local library folders and auto-refresh on changes
+- `42076f9` fix(local): open selected local library root in Finder and relabel menu
+- `20758df` fix(copy): make multi-copy resilient to library context changes
+- `aed4e9a` feat(local): add template-based local file organization settings
+- `91a046a` fix(local): normalize ABS series suffix when resolving folder template
+- `f94c268` Remove notarization instructions from README


### PR DESCRIPTION
## Summary
- add per-book metadata editor sheet for local-library items
- expose entry points from:
  - right-click context menu (`Edit Metadata…`)
  - three-dot bulk-actions popover (`Edit Selected Metadata…` when one item is selected)
- add quick actions in editor:
  - `Quick Match` (OpenLibrary match + apply)
  - `Re-Scan` (reload current item draft)
- add local metadata save flow for ABS-compatible core fields in local index

## Implemented fields (MVP)
- Title
- Authors (comma-separated)
- Narrators (stored in narrator text field)
- Series
- Description
- Genres
- Tags
- Publisher
- Language
- Publish Year

## Notes
- Current implementation is local-library metadata editing (persisted in local index).
- Remote ABS server-side writeback is not included in this PR.

Fixes #37.

## Validation
- swift test
